### PR TITLE
Add ParallelChunks function

### DIFF
--- a/msync/parallel.go
+++ b/msync/parallel.go
@@ -7,49 +7,29 @@ import (
 
 // Parallel spawns `workers` goroutines and invokes the function in each
 // routine from `start` to `end`. It blocks until all functions return.
-func Parallel(start, end, workers int, fn func(i int)) {
-	if end-start == 0 {
-		return
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(workers)
-
-	current := uint64(start)
-	for i := 0; i < workers; i++ {
-		go func() {
-			for {
-				x := int(atomic.AddUint64(&current, 1))
-				if x > end {
-					wg.Done()
-					return
-				}
-
-				fn(x - 1)
-			}
-		}()
-	}
-
-	wg.Wait()
+func Parallel(count, workers int, fn func(i int)) {
+	ParallelChunks(count, 1, workers, func(start, _ int) { fn(start) })
 }
 
 // ParallelRanges divides up the the domain into segments and dispatches
 // them to worker functions.
-func ParallelRanges(start, end, workers int, fn func(start, end int)) {
-	if end-start == 0 {
+func ParallelRanges(count, workers int, fn func(start, end int)) {
+	if count == 0 {
 		return
 	}
-	if end-start < workers {
-		fn(start, end)
+	if count < workers {
+		fn(0, count)
 		return
 	}
 
+	segment := count / workers
+
 	var wg sync.WaitGroup
 	for i := 0; i < workers; i++ {
-		a := i * start / end
-		b := (i + 1) * start / end
+		a := i * segment
+		b := (i + 1) * segment
 		if i == workers-1 {
-			b = end
+			b = count
 		}
 		if b-a == 0 {
 			continue
@@ -63,4 +43,47 @@ func ParallelRanges(start, end, workers int, fn func(start, end int)) {
 	}
 
 	wg.Wait()
+}
+
+// ParallelChunks divides the domain into chunks of "chunkSize" and feeds it
+// to the function, with bounded concurrency of `worker` functions.
+func ParallelChunks(count, chunkSize, workers int, fn func(start, end int)) {
+	if count == 0 {
+		return
+	}
+	if chunkSize == 0 {
+		panic("Cannot pass a chunkSize of 0 to ParallelChunks")
+	}
+	if count < chunkSize {
+		fn(0, count)
+		return
+	}
+
+	var (
+		wg      sync.WaitGroup
+		offset  int64
+		chunk64 = int64(chunkSize)
+	)
+
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			for {
+				upper := int(atomic.AddInt64(&offset, chunk64))
+				lower := upper - chunkSize
+				if lower >= count {
+					wg.Done()
+					return
+				}
+				if upper > count {
+					upper = count
+				}
+
+				fn(lower, upper)
+			}
+		}()
+	}
+
+	wg.Wait()
+
 }

--- a/msync/parallel_test.go
+++ b/msync/parallel_test.go
@@ -9,12 +9,20 @@ import (
 )
 
 func parallelTester(max, workers int, ch chan<- int) {
-	Parallel(0, max, workers, func(x int) {
+	Parallel(max, workers, func(x int) {
 		ch <- x
 	})
 }
 func parallelRangesTester(max, workers int, ch chan<- int) {
-	ParallelRanges(0, max, workers, func(start, end int) {
+	ParallelRanges(max, workers, func(start, end int) {
+		for i := start; i < end; i++ {
+			ch <- i
+		}
+	})
+}
+
+func parallelChunkTester(max, workers int, ch chan<- int) {
+	ParallelChunks(max, 3, workers, func(start, end int) {
 		for i := start; i < end; i++ {
 			ch <- i
 		}
@@ -50,8 +58,45 @@ func benchmarkRangeGenerator(b *testing.B, fn func(max, workers int, ch chan<- i
 	fn(b.N, runtime.GOMAXPROCS(0), ch)
 }
 
-func TestParallel(t *testing.T)      { testRangeGenerator(t, parallelTester) }
-func TestParallelRange(t *testing.T) { testRangeGenerator(t, parallelRangesTester) }
+func TestParallel(t *testing.T)       { testRangeGenerator(t, parallelTester) }
+func TestParallelRange(t *testing.T)  { testRangeGenerator(t, parallelRangesTester) }
+func TestParallelChunks(t *testing.T) { testRangeGenerator(t, parallelChunkTester) }
 
-func BenchmarkParallel(b *testing.B)      { benchmarkRangeGenerator(b, parallelTester) }
-func BenchmarkParallelRange(b *testing.B) { benchmarkRangeGenerator(b, parallelRangesTester) }
+func TestParallelChunksSizes(t *testing.T) {
+	max := 100
+	var expected []int
+	for i := 0; i < max; i++ {
+		expected = append(expected, i)
+	}
+
+	for chunkSize := 1; chunkSize < 100; chunkSize++ {
+		for workers := 1; workers < 5; workers++ {
+			ch := make(chan int, max)
+			ParallelChunks(max, chunkSize, workers, func(start, end int) {
+				if end-start > chunkSize {
+					t.Fatal("expected chunk size of", chunkSize, "got", end-start)
+				}
+				if end-start < chunkSize && end != max {
+					t.Fatal("expected to only get smaller chunk at end of generator")
+				}
+
+				for i := start; i < end; i++ {
+					ch <- i
+				}
+			})
+			close(ch)
+
+			var actual []int
+			for n := range ch {
+				actual = append(actual, n)
+			}
+
+			sort.Sort(sort.IntSlice(actual))
+			assert.Equal(t, expected, actual)
+		}
+	}
+}
+
+func BenchmarkParallel(b *testing.B)       { benchmarkRangeGenerator(b, parallelTester) }
+func BenchmarkParallelRange(b *testing.B)  { benchmarkRangeGenerator(b, parallelRangesTester) }
+func BenchmarkParallelChunks(b *testing.B) { benchmarkRangeGenerator(b, parallelChunkTester) }


### PR DESCRIPTION
Remove the `start, end` from other functions in favor of `count`, since `start` was basically always 0.